### PR TITLE
Add permission management features and seeding logic

### DIFF
--- a/src/EducationApp.API/Controllers/PermissionController.cs
+++ b/src/EducationApp.API/Controllers/PermissionController.cs
@@ -21,4 +21,11 @@ public class PermissionController : ControllerBase
 		await _permissionService.CreateAsync(dto);
 		return Ok("Permission created");
 	}
+
+	[HttpGet("get-all-permissions")]
+	public IActionResult GetAllPermissions()
+	{
+		var permissions = _permissionService.GetAll();
+		return Ok(permissions);
+    }
 }

--- a/src/EducationApp.API/Program.cs
+++ b/src/EducationApp.API/Program.cs
@@ -1,9 +1,9 @@
 using EducationApp.Application.DIContainer;
 using EducationApp.Application.Helpers;
 using EducationApp.Application.Helpers.GenerateJwt;
+using EducationApp.Application.Helpers.Seeder;
 using EducationApp.DataAccess.Database;
 using EducationApp.DataAccess.DependencyInjection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -88,6 +88,12 @@ if (builder.Environment.IsProduction() && builder.Configuration.GetValue<int?>("
 
 //var context = app.Services.CreateScope().ServiceProvider.GetRequiredService<EduDbContext>();
 //await context.Database.MigrateAsync();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<EduDbContext>();
+    await PermissionSeeder.SeedPermissionsAsync(db);
+}
 
 app.UseSwagger();
 app.UseSwaggerUI();

--- a/src/EducationApp.Application/DIcontainer/DependencyInjection.cs
+++ b/src/EducationApp.Application/DIcontainer/DependencyInjection.cs
@@ -40,6 +40,7 @@ public static class DependencyInjection
         services.AddScoped<IJwtTokenHandler, JwtTokenHandler>();
         services.AddScoped<IPasswordHasher, PasswordHasher>();
         services.AddScoped<IAuthService, AuthService>();
+        services.AddScoped<IPermissionService, PermissionService>();
 
         return services;
     }

--- a/src/EducationApp.Application/Helpers/Seeder/PermissionSeeder.cs
+++ b/src/EducationApp.Application/Helpers/Seeder/PermissionSeeder.cs
@@ -1,0 +1,29 @@
+﻿using EducationApp.DataAccess.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace EducationApp.Application.Helpers.Seeder;
+
+public static class PermissionSeeder
+{
+    public static async Task SeedPermissionsAsync(EduDbContext context)
+    {
+        var enumValues = Enum.GetValues(typeof(Core.Permission)).Cast<Core.Permission>()
+            .Select(e => new Core.Entities.Permission
+            {
+                Name = e.ToString(),
+                Description = e.ToString(),
+            });
+
+        var existingPermissions = await context.Permissions.ToListAsync();
+
+        var newPermissions = enumValues
+            .Where(p => !existingPermissions.Any(ep => ep.Name == p.Name))
+            .ToList();
+
+        if (newPermissions.Any())
+        {
+            context.Permissions.AddRange(newPermissions);
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/src/EducationApp.Application/Services/Interfaces/IPermissionService.cs
+++ b/src/EducationApp.Application/Services/Interfaces/IPermissionService.cs
@@ -1,8 +1,10 @@
 ﻿using EducationApp.Core.DTOs;
+using EducationApp.Core.Entities;
 
 namespace EducationApp.Application.Services.Interfaces;
 
 public interface IPermissionService
 {
 	Task CreateAsync(PermissionDto dto);
+	List<Permission> GetAll();
 }

--- a/src/EducationApp.Application/Services/PermissionService.cs
+++ b/src/EducationApp.Application/Services/PermissionService.cs
@@ -29,4 +29,11 @@ public class PermissionService : IPermissionService
 		_context.Permissions.Add(permission);
 		await _context.SaveChangesAsync();
 	}
+
+	public List<Permission> GetAll()
+	{
+		var permissions = _context.Permissions.ToList();
+
+		return permissions;
+    }
 }

--- a/src/EducationApp.Core/Enums/Permission.cs
+++ b/src/EducationApp.Core/Enums/Permission.cs
@@ -2,5 +2,13 @@
 
 public enum Permission
 {
+    #region Group Permissions
+
     GetAllGroupPermission,
+    GetByIdGroupPermission,
+    CreateGroupPermission,
+    UpdateGroupPermission,
+    DeleteGroupPermission,
+
+    #endregion
 }


### PR DESCRIPTION
- Implemented `GetAllPermissions` method in `PermissionController` to retrieve all permissions.
- Updated `Program.cs` to seed permissions during application startup.
- Registered `IPermissionService` in `DependencyInjection.cs`.
- Added `GetAll` method to `IPermissionService` and implemented it in `PermissionService`.
- Enhanced `Permission` enum with new group permission values.
- Created `PermissionSeeder` class to seed permissions based on enum values.